### PR TITLE
feat: add copy buttons to color inputs and variants

### DIFF
--- a/e2e/colors.test.ts
+++ b/e2e/colors.test.ts
@@ -214,4 +214,46 @@ test.describe('Color card', () => {
 		expect((await colors.all()).length).toBe(0);
 		await expect(resetButton).toBeDisabled();
 	});
+
+	test('should copy color values from input fields', async ({ page }) => {
+		await page.getByRole('button', { name: 'New color' }).click();
+
+		await hexInput.fill('#ff0000');
+		await hexInput.blur();
+
+		await page.getByRole('button', { name: 'Copy HEX' }).click();
+		const hexClipboard = await page.evaluate(() => navigator.clipboard.readText());
+		expect(hexClipboard).toBe('#ff0000');
+
+		await page.getByRole('button', { name: 'Copy RGB' }).click();
+		const rgbClipboard = await page.evaluate(() => navigator.clipboard.readText());
+		expect(rgbClipboard).toBe('rgb(255, 0, 0)');
+
+		await page.getByRole('button', { name: 'Copy HSL' }).click();
+		const hslClipboard = await page.evaluate(() => navigator.clipboard.readText());
+		expect(hslClipboard).toBe('hsl(0, 100%, 50%)');
+	});
+
+	test('should copy variant colors', async ({ page }) => {
+		await page.getByRole('button', { name: 'New color' }).click();
+
+		await hexInput.fill('#ff0000');
+		await hexInput.blur();
+		await page.getByTitle('Steps').fill('3');
+
+		// Test copying first variant (should be white)
+		await page.locator('.variant__box').nth(0).getByRole('button', { name: 'Copy' }).click();
+		const firstVariantClipboard = await page.evaluate(() => navigator.clipboard.readText());
+		expect(firstVariantClipboard).toBe('#ffffff');
+
+		// Test copying middle variant (should be the original color)
+		await page.locator('.variant__box').nth(1).getByRole('button', { name: 'Copy' }).click();
+		const middleVariantClipboard = await page.evaluate(() => navigator.clipboard.readText());
+		expect(middleVariantClipboard).toBe('#ff0000');
+
+		// Test copying last variant (should be black)
+		await page.locator('.variant__box').nth(2).getByRole('button', { name: 'Copy' }).click();
+		const lastVariantClipboard = await page.evaluate(() => navigator.clipboard.readText());
+		expect(lastVariantClipboard).toBe('#000000');
+	});
 });

--- a/e2e/colors.test.ts
+++ b/e2e/colors.test.ts
@@ -215,30 +215,33 @@ test.describe('Color card', () => {
 		await expect(resetButton).toBeDisabled();
 	});
 
-	test('should copy color values from input fields', async ({ page }) => {
+	test('should copy color values from input fields and from variants', async ({ page }) => {
 		await page.getByRole('button', { name: 'New color' }).click();
 
 		await hexInput.fill('#ff0000');
 		await hexInput.blur();
 
-		await page.getByRole('button', { name: 'Copy HEX' }).click();
+		await page
+			.locator('.color__input-item', { hasText: 'HEX' })
+			.getByRole('button', { name: 'Copy' })
+			.click();
 		const hexClipboard = await page.evaluate(() => navigator.clipboard.readText());
 		expect(hexClipboard).toBe('#ff0000');
 
-		await page.getByRole('button', { name: 'Copy RGB' }).click();
+		await page
+			.locator('.color__input-item', { hasText: 'RGB' })
+			.getByRole('button', { name: 'Copy' })
+			.click();
 		const rgbClipboard = await page.evaluate(() => navigator.clipboard.readText());
 		expect(rgbClipboard).toBe('rgb(255, 0, 0)');
 
-		await page.getByRole('button', { name: 'Copy HSL' }).click();
+		await page
+			.locator('.color__input-item', { hasText: 'HSL' })
+			.getByRole('button', { name: 'Copy' })
+			.click();
 		const hslClipboard = await page.evaluate(() => navigator.clipboard.readText());
 		expect(hslClipboard).toBe('hsl(0, 100%, 50%)');
-	});
 
-	test('should copy variant colors', async ({ page }) => {
-		await page.getByRole('button', { name: 'New color' }).click();
-
-		await hexInput.fill('#ff0000');
-		await hexInput.blur();
 		await page.getByTitle('Steps').fill('3');
 
 		// Test copying first variant (should be white)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { baseConfig } from './playwright.config.base';
 
 export default {
-	...baseConfig
+	...baseConfig,
+	use: {
+		permissions: ['clipboard-read', 'clipboard-write']
+	}
 };

--- a/src/lib/components/ButtonCopy.svelte
+++ b/src/lib/components/ButtonCopy.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	let { content }: { content: string } = $props();
+
+	function copyContent() {
+		navigator.clipboard.writeText(content);
+	}
+</script>
+
+<button title="Copy" class="button-copy" onclick={copyContent}>Copy</button>

--- a/src/routes/ColorCard.svelte
+++ b/src/routes/ColorCard.svelte
@@ -3,6 +3,8 @@
 	import ColorPicker, { ChromeVariant } from 'svelte-awesome-color-picker';
 	import { linear, quadIn, quadInOut, quadOut } from 'svelte/easing';
 
+	import ButtonCopy from '$lib/components/ButtonCopy.svelte';
+
 	let { color = $bindable() }: { color: Colord } = $props();
 
 	// It seems that the ColorPicker component doesn't work as expected when binded
@@ -66,9 +68,7 @@
 			<label for="color-hex">HEX</label>
 			<div class="color__input-copy">
 				<input id="color-hex" type="text" value={color.toHex()} onblur={handleColorInput} />
-				<button onclick={() => navigator.clipboard.writeText(color.toHex())} title="Copy">
-					Copy
-				</button>
+				<ButtonCopy content={color.toHex()} />
 			</div>
 		</div>
 
@@ -76,9 +76,7 @@
 			<label for="color-rgb">RGB</label>
 			<div class="color__input-copy">
 				<input id="color-rgb" type="text" value={color.toRgbString()} onblur={handleColorInput} />
-				<button onclick={() => navigator.clipboard.writeText(color.toRgbString())} title="Copy">
-					Copy
-				</button>
+				<ButtonCopy content={color.toRgbString()} />
 			</div>
 		</div>
 
@@ -86,9 +84,7 @@
 			<label for="color-hsl">HSL</label>
 			<div class="color__input-copy">
 				<input id="color-hsl" type="text" value={color.toHslString()} onblur={handleColorInput} />
-				<button onclick={() => navigator.clipboard.writeText(color.toHslString())} title="Copy">
-					Copy
-				</button>
+				<ButtonCopy content={color.toHslString()} />
 			</div>
 		</div>
 	</fieldset>
@@ -199,6 +195,5 @@
 	.variant__copy {
 		background-color: white;
 		color: black;
-		cursor: pointer;
 	}
 </style>

--- a/src/routes/ColorCard.svelte
+++ b/src/routes/ColorCard.svelte
@@ -104,13 +104,7 @@
 		{#each variants as variant}
 			<div class="variant__box" style={`background-color: ${variant.toHex()}`}>
 				<p class="variant__text">{variant.toHex()}</p>
-				<button
-					class="variant__copy"
-					onclick={() => navigator.clipboard.writeText(variant.toHex())}
-					title="Copy"
-				>
-					Copy
-				</button>
+				<ButtonCopy content={variant.toHex()} />
 			</div>
 		{/each}
 	</div>
@@ -190,10 +184,5 @@
 
 	.variant__box {
 		justify-content: space-between;
-	}
-
-	.variant__copy {
-		background-color: white;
-		color: black;
 	}
 </style>

--- a/src/routes/ColorCard.svelte
+++ b/src/routes/ColorCard.svelte
@@ -64,17 +64,32 @@
 	<fieldset class="color__fieldset">
 		<div class="color__input-item">
 			<label for="color-hex">HEX</label>
-			<input id="color-hex" type="text" value={color.toHex()} onblur={handleColorInput} />
+			<div class="color__input-copy">
+				<input id="color-hex" type="text" value={color.toHex()} onblur={handleColorInput} />
+				<button onclick={() => navigator.clipboard.writeText(color.toHex())} title="Copy">
+					Copy
+				</button>
+			</div>
 		</div>
 
 		<div class="color__input-item">
 			<label for="color-rgb">RGB</label>
-			<input id="color-rgb" type="text" value={color.toRgbString()} onblur={handleColorInput} />
+			<div class="color__input-copy">
+				<input id="color-rgb" type="text" value={color.toRgbString()} onblur={handleColorInput} />
+				<button onclick={() => navigator.clipboard.writeText(color.toRgbString())} title="Copy">
+					Copy
+				</button>
+			</div>
 		</div>
 
 		<div class="color__input-item">
 			<label for="color-hsl">HSL</label>
-			<input id="color-hsl" type="text" value={color.toHslString()} onblur={handleColorInput} />
+			<div class="color__input-copy">
+				<input id="color-hsl" type="text" value={color.toHslString()} onblur={handleColorInput} />
+				<button onclick={() => navigator.clipboard.writeText(color.toHslString())} title="Copy">
+					Copy
+				</button>
+			</div>
 		</div>
 	</fieldset>
 
@@ -93,6 +108,13 @@
 		{#each variants as variant}
 			<div class="variant__box" style={`background-color: ${variant.toHex()}`}>
 				<p class="variant__text">{variant.toHex()}</p>
+				<button
+					class="variant__copy"
+					onclick={() => navigator.clipboard.writeText(variant.toHex())}
+					title="Copy"
+				>
+					Copy
+				</button>
 			</div>
 		{/each}
 	</div>
@@ -132,6 +154,12 @@
 		width: 100%;
 	}
 
+	.color__input-copy {
+		display: flex;
+		gap: 5px;
+		width: 100%;
+	}
+
 	.variants__controls {
 		margin-top: 10px;
 		width: 100%;
@@ -162,5 +190,15 @@
 
 	.variant__text {
 		color: white;
+	}
+
+	.variant__box {
+		justify-content: space-between;
+	}
+
+	.variant__copy {
+		background-color: white;
+		color: black;
+		cursor: pointer;
 	}
 </style>


### PR DESCRIPTION
I know the final design will have the Copy icon instead of text but I wrote the tests like this for now.